### PR TITLE
remove error messages, enable rapid shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN sh /add_self_signed_certs.sh
 
 # Set the default command to execute
 # when creating a new container
-CMD sh /configure_nginx.sh
+CMD ["sh", "configure_nginx.sh"]

--- a/configure_nginx.sh
+++ b/configure_nginx.sh
@@ -1,5 +1,6 @@
-${PORT=443}
-${TARGET_PORT=80}
+PORT=${PORT:-443}
+TARGET_PORT=${TARGET_PORT:-80}
+
 echo "Starting Proxy: $PORT"
 echo "Target Docker Port: $TARGET_PORT"
 
@@ -7,5 +8,6 @@ cat nginx.conf.template | \
     sed "s|{{listenPort}}|$PORT|g" | \
     sed "s|{{targetPort}}|$TARGET_PORT|g" > /etc/nginx/nginx.conf
 
-service nginx start
+# Use exec so nginx can get signals directly
+exec nginx
 echo "Something Broke!"


### PR DESCRIPTION
When using your (very handy) container, I noticed

- it was spitting out some error messages when starting up, as it was attempting to run `443` and `80` as commands
- it was taking 10 seconds to `docker stop` the container, because the wrapper shell script (was wrapping another shell script that was wrapping another shell script) so the `SIGTERM` sent by `docker stop` was not getting to `nginx`.

This PR addresses both of those issues.